### PR TITLE
implement record-level and word-level inverted indexes

### DIFF
--- a/indexing.py
+++ b/indexing.py
@@ -1,7 +1,8 @@
+from turtle import position
 import json_reader
 
 
-def inverted_index():
+def record_level_inverted_index():
     
     json_data = json_reader.reader("data.json")
     unique_tokens_list = list()
@@ -14,7 +15,7 @@ def inverted_index():
         unique_terms = set(json_object['paper_abstract'])
         unique_tokens_list.extend(list(unique_terms))
     
-    # create the inverted index 
+    # create the inverted index (record level)
 
     for unique_token in unique_tokens_list:
         for data in json_data:
@@ -24,4 +25,32 @@ def inverted_index():
         found_in_papers.clear()
          
     return inverted_result
+
+
+def word_level_inverted_index():
     
+    json_data = json_reader.reader("data.json")
+    all_tokens_list = list()
+    positions_list = list()
+    found_item = 0
+    inverted_result = dict()
+    
+    # get all tokens (not unique)
+
+    for data in json_data:
+        all_tokens_list.extend(data['paper_abstract'])
+        
+    # create the inverted index (word level)
+        
+    for token in all_tokens_list:
+        for data in json_data:
+            for index, item in enumerate(data['paper_abstract']):
+                if token == item:
+                    found_item += 1 
+                    positions = (data['paper_id'], index)
+                    positions_list.append(positions)
+        inverted_result[token] = [positions_list.copy(), found_item]
+        positions_list.clear()
+        found_item = 0
+        
+    return inverted_result


### PR DESCRIPTION
We only implemented a **record-level** inverse index. It contains a list of references to documents for each **unique** word. The **word-level** inverse index contains the positions of each **(not unique)** word within a document, but also the term frequency. 

This Pull Request renames our first implementation of inverse index to record-level and adds the word-level inverse index. 

closes issue #13 